### PR TITLE
Fix unauthorized response status when login required

### DIFF
--- a/tapas_design/app/controllers/application_controller.rb
+++ b/tapas_design/app/controllers/application_controller.rb
@@ -31,8 +31,8 @@ class ApplicationController < ActionController::API
     end
 
     def require_logged_in
-        if !logged_in?
-            render json: { errors: ['Must be logged in to do that']}, status: unauthorized
+        unless logged_in?
+            render json: { errors: ['Must be logged in to do that'] }, status: :unauthorized
         end
     end
 


### PR DESCRIPTION
## Summary
- return a proper 401 status symbol when blocking unauthorized access in ApplicationController
- keep the helper readable by switching to `unless logged_in?`

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e3a461284833191821e3f3f5305c4)